### PR TITLE
Add scoreboard and enhanced status messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,10 @@
             <div class="cell" data-cell></div>
             <div class="cell" data-cell></div>
         </div>
-        <button class="reset-btn" id="resetBtn">Reset Game</button>
+        <div class="controls">
+            <button class="swap-btn" id="swapBtn">Swap Players</button>
+            <button class="reset-btn" id="resetBtn">Reset Game</button>
+        </div>
     </div>
     <script src="script.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,20 @@
             <div class="current-player">Current Player: <span id="currentPlayer">X</span></div>
             <div class="status" id="status"></div>
         </div>
+        <div class="scoreboard" aria-label="Scoreboard">
+            <div class="score-card" data-score-card="X">
+                <span class="label">Player X</span>
+                <span class="score" id="scoreX">0</span>
+            </div>
+            <div class="score-card" data-score-card="draws">
+                <span class="label">Draws</span>
+                <span class="score" id="scoreDraws">0</span>
+            </div>
+            <div class="score-card" data-score-card="O">
+                <span class="label">Player O</span>
+                <span class="score" id="scoreO">0</span>
+            </div>
+        </div>
         <div class="game-board" id="gameBoard">
             <div class="cell" data-cell></div>
             <div class="cell" data-cell></div>

--- a/script.js
+++ b/script.js
@@ -3,10 +3,25 @@ const currentPlayerDisplay = document.getElementById('currentPlayer');
 const statusDisplay = document.getElementById('status');
 const resetBtn = document.getElementById('resetBtn');
 const cells = document.querySelectorAll('[data-cell]');
+const scoreDisplays = {
+    X: document.getElementById('scoreX'),
+    O: document.getElementById('scoreO'),
+    draws: document.getElementById('scoreDraws')
+};
+const scoreCards = {
+    X: document.querySelector('[data-score-card="X"]'),
+    O: document.querySelector('[data-score-card="O"]'),
+    draws: document.querySelector('[data-score-card="draws"]')
+};
 
 let currentPlayer = 'X';
 let gameActive = true;
 let gameState = ['', '', '', '', '', '', '', '', ''];
+const scores = {
+    X: 0,
+    O: 0,
+    draws: 0
+};
 
 const winningConditions = [
     [0, 1, 2], // Top row
@@ -24,10 +39,12 @@ function startGame() {
     gameState = ['', '', '', '', '', '', '', '', ''];
     currentPlayer = 'X';
     currentPlayerDisplay.textContent = currentPlayer;
-    statusDisplay.textContent = '';
+    setStatus('Player X, it\'s your turn!');
+    updateScoreboard();
     cells.forEach(cell => {
         cell.textContent = '';
         cell.classList.remove('x', 'o', 'winner');
+        cell.removeEventListener('click', handleCellClick);
         cell.addEventListener('click', handleCellClick, { once: true });
     });
 }
@@ -44,15 +61,12 @@ function handleCellClick(e) {
     cell.classList.add(currentPlayer.toLowerCase());
 
     if (checkWin()) {
-        statusDisplay.textContent = `Player ${currentPlayer} wins!`;
-        gameActive = false;
-        highlightWinningCells();
+        endGame(currentPlayer);
         return;
     }
 
     if (checkDraw()) {
-        statusDisplay.textContent = "It's a draw!";
-        gameActive = false;
+        endGame('draw');
         return;
     }
 
@@ -62,6 +76,7 @@ function handleCellClick(e) {
 function switchPlayer() {
     currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
     currentPlayerDisplay.textContent = currentPlayer;
+    updateTurnMessage();
 }
 
 function checkWin() {
@@ -76,9 +91,9 @@ function checkDraw() {
     return gameState.every(cell => cell !== '');
 }
 
-function highlightWinningCells() {
+function highlightWinningCells(winner) {
     winningConditions.forEach(condition => {
-        if (condition.every(index => gameState[index] === currentPlayer)) {
+        if (condition.every(index => gameState[index] === winner)) {
             condition.forEach(index => {
                 cells[index].classList.add('winner');
             });
@@ -88,6 +103,50 @@ function highlightWinningCells() {
 
 function resetGame() {
     startGame();
+}
+
+function setStatus(message, stateClass = '') {
+    statusDisplay.textContent = message;
+    statusDisplay.classList.remove('status-win', 'status-draw');
+    if (stateClass) {
+        statusDisplay.classList.add(stateClass);
+    }
+}
+
+function updateTurnMessage() {
+    if (!gameActive) {
+        return;
+    }
+    setStatus(`Player ${currentPlayer}, it's your turn!`);
+}
+
+function endGame(result) {
+    gameActive = false;
+    if (result === 'draw') {
+        setStatus("It's a draw!", 'status-draw');
+        scores.draws += 1;
+    } else {
+        setStatus(`Player ${result} wins!`, 'status-win');
+        highlightWinningCells(result);
+        scores[result] += 1;
+    }
+    updateScoreboard();
+}
+
+function updateScoreboard() {
+    scoreDisplays.X.textContent = scores.X;
+    scoreDisplays.O.textContent = scores.O;
+    scoreDisplays.draws.textContent = scores.draws;
+
+    Object.values(scoreCards).forEach(card => card.classList.remove('leader'));
+    const highestScore = Math.max(...Object.values(scores));
+    if (highestScore > 0) {
+        Object.entries(scores).forEach(([player, value]) => {
+            if (value === highestScore) {
+                scoreCards[player].classList.add('leader');
+            }
+        });
+    }
 }
 
 // Event listeners

--- a/script.js
+++ b/script.js
@@ -2,6 +2,7 @@ const gameBoard = document.getElementById('gameBoard');
 const currentPlayerDisplay = document.getElementById('currentPlayer');
 const statusDisplay = document.getElementById('status');
 const resetBtn = document.getElementById('resetBtn');
+const swapBtn = document.getElementById('swapBtn');
 const cells = document.querySelectorAll('[data-cell]');
 const scoreDisplays = {
     X: document.getElementById('scoreX'),
@@ -34,12 +35,12 @@ const winningConditions = [
     [2, 4, 6]  // Diagonal top-right to bottom-left
 ];
 
-function startGame() {
+function startGame(startingPlayer = 'X') {
     gameActive = true;
     gameState = ['', '', '', '', '', '', '', '', ''];
-    currentPlayer = 'X';
+    currentPlayer = startingPlayer;
     currentPlayerDisplay.textContent = currentPlayer;
-    setStatus('Player X, it\'s your turn!');
+    setStatus(`Player ${currentPlayer}, it's your turn!`);
     updateScoreboard();
     cells.forEach(cell => {
         cell.textContent = '';
@@ -149,8 +150,16 @@ function updateScoreboard() {
     }
 }
 
+function swapPlayers() {
+    [scores.X, scores.O] = [scores.O, scores.X];
+    const nextStarter = currentPlayer === 'X' ? 'O' : 'X';
+    startGame(nextStarter);
+    setStatus(`Players swapped! Player ${currentPlayer}, it's your turn!`);
+}
+
 // Event listeners
 resetBtn.addEventListener('click', resetGame);
+swapBtn.addEventListener('click', swapPlayers);
 
 // Start the game when the page loads
 document.addEventListener('DOMContentLoaded', startGame);

--- a/styles.css
+++ b/styles.css
@@ -35,6 +35,64 @@ h1 {
     margin-bottom: 20px;
 }
 
+.status-win {
+    color: #28a745;
+    font-weight: 600;
+}
+
+.status-draw {
+    color: #ffc107;
+    font-weight: 600;
+}
+
+.scoreboard {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+    margin-bottom: 25px;
+}
+
+.score-card {
+    background: #f1f5ff;
+    border-radius: 15px;
+    padding: 12px 10px;
+    box-shadow: inset 0 0 0 2px rgba(102, 126, 234, 0.2);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.score-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 10px 20px rgba(102, 126, 234, 0.2);
+}
+
+.score-card.leader {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    box-shadow: 0 12px 25px rgba(102, 126, 234, 0.35);
+}
+
+.score-card.leader .label,
+.score-card.leader .score {
+    color: #fff;
+}
+
+.score-card .label {
+    font-size: 0.9em;
+    color: #495057;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.score-card .score {
+    font-size: 1.8em;
+    font-weight: bold;
+    color: #4c51bf;
+}
+
 .current-player {
     font-size: 1.2em;
     color: #555;
@@ -156,6 +214,18 @@ h1 {
 @media (max-width: 480px) {
     .container {
         padding: 20px;
+    }
+
+    .scoreboard {
+        gap: 8px;
+    }
+
+    .score-card {
+        padding: 10px 8px;
+    }
+
+    .score-card .score {
+        font-size: 1.5em;
     }
 
     h1 {

--- a/styles.css
+++ b/styles.css
@@ -174,24 +174,50 @@ h1 {
     }
 }
 
-.reset-btn {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
-    border: none;
-    padding: 12px 30px;
-    border-radius: 25px;
-    font-size: 1.1em;
-    font-weight: bold;
-    cursor: pointer;
-    transition: all 0.3s ease;
+.controls {
+    display: flex;
+    justify-content: center;
+    gap: 12px;
+    flex-wrap: wrap;
     margin-top: 20px;
 }
 
-.reset-btn:hover {
-    transform: translateY(-2px);
+.swap-btn,
+.reset-btn {
+    color: white;
+    border: none;
+    padding: 12px 28px;
+    border-radius: 25px;
+    font-size: 1.05em;
+    font-weight: bold;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.swap-btn {
+    background: linear-gradient(135deg, #ff9a9e 0%, #fad0c4 100%);
+    box-shadow: 0 10px 20px rgba(255, 154, 158, 0.35);
+}
+
+.reset-btn {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     box-shadow: 0 10px 20px rgba(102, 126, 234, 0.3);
 }
 
+.swap-btn:hover,
+.reset-btn:hover {
+    transform: translateY(-2px);
+}
+
+.swap-btn:hover {
+    box-shadow: 0 12px 24px rgba(255, 154, 158, 0.45);
+}
+
+.reset-btn:hover {
+    box-shadow: 0 12px 24px rgba(102, 126, 234, 0.4);
+}
+
+.swap-btn:active,
 .reset-btn:active {
     transform: translateY(0);
 }


### PR DESCRIPTION
## Summary
- add a responsive scoreboard section that tracks X wins, O wins, and draws
- enhance the game logic to persist round results, highlight leaders, and show turn messaging
- style the new interface elements with gradients and stateful status colors

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68cbcae5a9788323b1d5bcc34c5fbb69